### PR TITLE
fix(card): prevent save button from activating when status is unchanged

### DIFF
--- a/src/components/Card/CardView.jsx
+++ b/src/components/Card/CardView.jsx
@@ -2,17 +2,23 @@ import React from "react";
 import StatusDropdown from "../StatusDropdown";
 
 export default function CardView({ task, columns, currentColumnId, onSelect }) {
-    return (
-        <div className="card-view">
-            <h3 className="task-name">{task.title}</h3>
-            <div className="status-block">
-                <label className="card-title w-600">Status:</label>
-                <StatusDropdown columns={columns} currentColumnId={currentColumnId} onSelect={onSelect} />
-            </div>
-            <div className="description-section">
-                <h3 className="card-title w-600">Descrição:</h3>
-                {task.description || "Nenhuma descrição disponível."}
-            </div>
-        </div>
-    );
+  return (
+    <div className="card-view">
+      <h3 className="task-name">{task.title}</h3>
+
+      <div className="status-block">
+        <label className="card-title w-600">Status:</label>
+        <StatusDropdown
+          columns={columns}
+          currentColumnId={currentColumnId}
+          onSelect={onSelect}
+        />
+      </div>
+
+      <div className="description-section">
+        <h3 className="card-title w-600">Descrição:</h3>
+        {task.description || "Nenhuma descrição disponível."}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
- Store column ID locally in CardTask instead of canonical status
- Compare column IDs to detect real changes and enable save button correctly
- Align CardView and CardEdit to use currentColumnId consistently
- Convert column ID to canonical status only when saving or moving a task